### PR TITLE
add support for HTTP Basic Auth and fix  HTTP headers 

### DIFF
--- a/lib/ldp/client/methods.rb
+++ b/lib/ldp/client/methods.rb
@@ -12,7 +12,7 @@ module Ldp::Client::Methods
       @username = http_client[1]
       @password = http_client[2]
       @http = Faraday.new http_client.first
-      http.basic_auth(user,passwd) 
+      http.basic_auth(user,passwd)
     else
       @http = Faraday.new *http_client
     end
@@ -55,7 +55,6 @@ module Ldp::Client::Methods
       end
 
       yield req if block_given?
-      Rails.logger.debug "req: #{req.inspect}"
     end
 
     if Ldp::Response.resource? resp
@@ -137,7 +136,7 @@ module Ldp::Client::Methods
           when 412
             Ldp::EtagMismatch.new(resp.body)
           else
-            Ldp::HttpError.new("STATUS: #{resp.status} #{resp.body[0, 1000]}... #{resp.inspect}")
+            Ldp::HttpError.new("STATUS: #{resp.status} #{resp.body[0, 1000]}...")
           end
       end
     end

--- a/lib/ldp/resource/rdf_source.rb
+++ b/lib/ldp/resource/rdf_source.rb
@@ -17,7 +17,9 @@ module Ldp
 
     def create
       super do |req|
-        req.headers = { "Content-Type" => "text/turtle" }
+        if req.headers["Content-Type"] != "text/turtle"
+          req.headers["Content-Type"] = "text/turtle"
+        end
       end
     end
 

--- a/spec/lib/ldp/client_spec.rb
+++ b/spec/lib/ldp/client_spec.rb
@@ -61,6 +61,12 @@ describe "Ldp::Client" do
       client = Ldp::Client.new "http://example.com"
       expect(client.http.host).to eq("example.com")
     end
+
+    it "should create a connection from Faraday constructor params including basic auth headers" do
+      client = Ldp::Client.new "http://example.com", "username", "password"
+      expect(client.http.host).to eq("example.com")
+      expect(client.http.headers).to include({"Authorization" => "Basic dXNlcm5hbWU6cGFzc3dvcmQ="})
+    end
   end
 
   describe "get" do
@@ -132,13 +138,13 @@ describe "Ldp::Client" do
 
     it "should set default Content-type" do
       subject.post "a_container", 'foo' do |req|
-        expect(req.headers).to eq({ "Content-Type" => "text/turtle" })
+        expect(req.headers).to include({ "Content-Type" => "text/turtle" })
       end
     end
 
     it "should set headers" do
       subject.post "a_container", 'foo', {'Content-Type' => 'application/pdf'} do |req|
-        expect(req.headers).to eq({ "Content-Type" => "application/pdf" })
+        expect(req.headers).to include({ "Content-Type" => "application/pdf" })
       end
     end
 
@@ -164,7 +170,7 @@ describe "Ldp::Client" do
 
     it "should set headers" do
       subject.put "a_resource", 'payload', {'Content-Type' => 'application/pdf'} do |req|
-        expect(req.headers).to eq({ "Content-Type" => "application/pdf" })
+        expect(req.headers).to include({ "Content-Type" => "application/pdf" })
       end
     end
 


### PR DESCRIPTION
simple HTTP Basic auth support using Faraday's basic auth middleware and fixing code where http headers were unconditionally overwritten, thus removing added auth.